### PR TITLE
Cross-Platform script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DevEnv-Install
-Install all common development libraries for any system with a Bash shell (OS X, *NIX, etc.)
+Install all common NodeJS development libraries for any system with a Bash shell (OS X, *NIX, etc.)
 
 ## Running
 
@@ -7,11 +7,13 @@ To run and install my DevEnv, clone this repo and run
 
 ```bash
 
-chmod u+x ./install.sh
-sudo ./install.sh
+chmod +x ./install.sh
+./install.sh
 
 ```
 
-## Why sudo?
+## Why not sudo?
 
-`sudo` (NOT ROOT USER) is needed to install all dependencies.
+Node Version Manager (nvm) installs NodeJS locally, not system wide.
+Only your user will have access to NodeJS unless other users also install
+nvm.

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,17 @@
+#!/usr/bin/env bash
 # thetayloredman/DevEnv-Install
 
-# node.js
-curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh
-bash nodesource_setup.sh
-sudo apt-get install nodejs
-sudo apt-get install npm
+# nvm
+cd $HOME/Downloads
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh
+mv install.sh nvm-install.sh
+./nvm-install.sh
 
-# add npm stuff
+# NodeJS
+nvm install node
+npm up -g npm
+
+# Common NodeJS development packages
 npm i -g n;
 npm i -g typescript;
 npm i -g prettier;
@@ -19,5 +24,5 @@ npm i -g jsdoc;
 npm i -g codecov;
 npm i -g browserify;
 
-echo "Finished.";
-echo "You should restart your system.";
+echo "Finished"
+echo "Restart your terminal session to use nodejs and npm."


### PR DESCRIPTION
APT is not a cross platform package manager, since it is limited to Debian-based linux distributions.

I have modified the script so nvm (node version manager) is used to install nodejs and npm.